### PR TITLE
WF Update t3.small instances

### DIFF
--- a/portal_objects/metaworkflows/Illumina_FASTQ_quality_metrics.yaml
+++ b/portal_objects/metaworkflows/Illumina_FASTQ_quality_metrics.yaml
@@ -316,6 +316,6 @@ workflows:
         - m7a.medium
       ebs_size: 10
       ebs_optimized: True
-      spot_instance: True
+      spot_instance: False
       run_name: run_parse-qc_FASTQ_Quality_Metrics_short_reads
       behavior_on_capacity_limit: wait_and_retry

--- a/portal_objects/metaworkflows/Illumina_FASTQ_quality_metrics.yaml
+++ b/portal_objects/metaworkflows/Illumina_FASTQ_quality_metrics.yaml
@@ -83,7 +83,9 @@ workflows:
     ####################################
     config:
       instance_type:
-        - t3.small
+        - c7a.medium
+        - c8a.medium
+        - m7a.medium
       ebs_size: '1.1x'
       ebs_optimized: True
       spot_instance: True
@@ -121,7 +123,9 @@ workflows:
     ####################################
     config:
       instance_type:
-        - t3.small
+        - c7a.medium
+        - c8a.medium
+        - m7a.medium
       ebs_size: '1.1x'
       ebs_optimized: True
       spot_instance: True
@@ -307,7 +311,9 @@ workflows:
     ####################################
     config:
       instance_type:
-        - t3.small
+        - c7a.medium
+        - c8a.medium
+        - m7a.medium
       ebs_size: 10
       ebs_optimized: True
       spot_instance: True

--- a/portal_objects/metaworkflows/long_reads_BAM_quality_metrics_GRCh38.yaml
+++ b/portal_objects/metaworkflows/long_reads_BAM_quality_metrics_GRCh38.yaml
@@ -178,7 +178,9 @@ workflows:
     ####################################
     config:
       instance_type:
-        - t3.small
+        - c7a.medium
+        - c8a.medium
+        - m7a.medium
       ebs_size: "1.1x"
       ebs_optimized: True
       spot_instance: True
@@ -719,7 +721,9 @@ workflows:
     ####################################
     config:
       instance_type:
-        - t3.small
+        - c7a.medium
+        - c8a.medium
+        - m7a.medium
       ebs_size: 10
       ebs_optimized: True
       spot_instance: True

--- a/portal_objects/metaworkflows/long_reads_BAM_quality_metrics_GRCh38.yaml
+++ b/portal_objects/metaworkflows/long_reads_BAM_quality_metrics_GRCh38.yaml
@@ -726,6 +726,6 @@ workflows:
         - m7a.medium
       ebs_size: 10
       ebs_optimized: True
-      spot_instance: True
+      spot_instance: False
       run_name: run_parse-qc_BAM_Quality_Metrics_single-end_verifybamid2
       behavior_on_capacity_limit: wait_and_retry

--- a/portal_objects/metaworkflows/long_reads_FASTQ_quality_metrics.yaml
+++ b/portal_objects/metaworkflows/long_reads_FASTQ_quality_metrics.yaml
@@ -312,7 +312,9 @@ workflows:
     ####################################
     config:
       instance_type:
-        - t3.small
+        - c7a.medium
+        - c8a.medium
+        - m7a.medium
       ebs_size: 10
       ebs_optimized: True
       spot_instance: True

--- a/portal_objects/metaworkflows/long_reads_FASTQ_quality_metrics.yaml
+++ b/portal_objects/metaworkflows/long_reads_FASTQ_quality_metrics.yaml
@@ -317,6 +317,6 @@ workflows:
         - m7a.medium
       ebs_size: 10
       ebs_optimized: True
-      spot_instance: True
+      spot_instance: False
       run_name: run_parse-qc_FASTQ_Quality_Metrics_long_reads
       behavior_on_capacity_limit: wait_and_retry

--- a/portal_objects/metaworkflows/paired-end_short_reads_BAM_quality_metrics_GRCh38.yaml
+++ b/portal_objects/metaworkflows/paired-end_short_reads_BAM_quality_metrics_GRCh38.yaml
@@ -806,6 +806,6 @@ workflows:
         - m7a.medium
       ebs_size: 10
       ebs_optimized: True
-      spot_instance: True
+      spot_instance: False
       run_name: run_parse-qc_BAM_Quality_Metrics_paired-end
       behavior_on_capacity_limit: wait_and_retry

--- a/portal_objects/metaworkflows/paired-end_short_reads_BAM_quality_metrics_GRCh38.yaml
+++ b/portal_objects/metaworkflows/paired-end_short_reads_BAM_quality_metrics_GRCh38.yaml
@@ -196,7 +196,9 @@ workflows:
     ####################################
     config:
       instance_type:
-        - t3.small
+        - c7a.medium
+        - c8a.medium
+        - m7a.medium
       ebs_size: "1.1x"
       ebs_optimized: True
       spot_instance: True
@@ -799,7 +801,9 @@ workflows:
     ####################################
     config:
       instance_type:
-        - t3.small
+        - c7a.medium
+        - c8a.medium
+        - m7a.medium
       ebs_size: 10
       ebs_optimized: True
       spot_instance: True

--- a/portal_objects/metaworkflows/sample_identity_check.yaml
+++ b/portal_objects/metaworkflows/sample_identity_check.yaml
@@ -180,7 +180,9 @@ workflows:
     ####################################
     config:
       instance_type:
-        - t3.small
+        - c7a.medium
+        - c8a.medium
+        - m7a.medium
       ebs_size: 10
       ebs_optimized: True
       spot_instance: True
@@ -228,7 +230,9 @@ workflows:
     ####################################
     config:
       instance_type:
-        - t3.small
+        - c7a.medium
+        - c8a.medium
+        - m7a.medium
       ebs_size: 10
       ebs_optimized: True
       spot_instance: True

--- a/portal_objects/metaworkflows/sample_identity_check.yaml
+++ b/portal_objects/metaworkflows/sample_identity_check.yaml
@@ -235,6 +235,6 @@ workflows:
         - m7a.medium
       ebs_size: 10
       ebs_optimized: True
-      spot_instance: True
+      spot_instance: False
       run_name: run_parse-qc_Relatedness_Quality_Metrics
       behavior_on_capacity_limit: wait_and_retry

--- a/portal_objects/metaworkflows/samtools_mosdepth_bam.yaml
+++ b/portal_objects/metaworkflows/samtools_mosdepth_bam.yaml
@@ -188,6 +188,6 @@ workflows:
         - m7a.medium
       ebs_size: 10
       ebs_optimized: True
-      spot_instance: True
+      spot_instance: False
       run_name: run_parse-qc_BAM_Samtools_Mosdepth
       behavior_on_capacity_limit: wait_and_retry

--- a/portal_objects/metaworkflows/samtools_mosdepth_bam.yaml
+++ b/portal_objects/metaworkflows/samtools_mosdepth_bam.yaml
@@ -183,7 +183,9 @@ workflows:
     ####################################
     config:
       instance_type:
-        - t3.small
+        - c7a.medium
+        - c8a.medium
+        - m7a.medium
       ebs_size: 10
       ebs_optimized: True
       spot_instance: True

--- a/portal_objects/metaworkflows/short_reads_FASTQ_quality_metrics.yaml
+++ b/portal_objects/metaworkflows/short_reads_FASTQ_quality_metrics.yaml
@@ -216,6 +216,6 @@ workflows:
         - m7a.medium
       ebs_size: 10
       ebs_optimized: True
-      spot_instance: True
+      spot_instance: False
       run_name: run_parse-qc_FASTQ_Quality_Metrics_short_reads
       behavior_on_capacity_limit: wait_and_retry

--- a/portal_objects/metaworkflows/short_reads_FASTQ_quality_metrics.yaml
+++ b/portal_objects/metaworkflows/short_reads_FASTQ_quality_metrics.yaml
@@ -211,7 +211,9 @@ workflows:
     ####################################
     config:
       instance_type:
-        - t3.small
+        - c7a.medium
+        - c8a.medium
+        - m7a.medium
       ebs_size: 10
       ebs_optimized: True
       spot_instance: True

--- a/portal_objects/metaworkflows/ultra-long_reads_BAM_quality_metrics_GRCh38.yaml
+++ b/portal_objects/metaworkflows/ultra-long_reads_BAM_quality_metrics_GRCh38.yaml
@@ -183,7 +183,9 @@ workflows:
     ####################################
     config:
       instance_type:
-        - t3.small
+        - c7a.medium
+        - c8a.medium
+        - m7a.medium
       ebs_size: "1.1x"
       ebs_optimized: True
       spot_instance: True
@@ -716,7 +718,9 @@ workflows:
     ####################################
     config:
       instance_type:
-        - t3.small
+        - c7a.medium
+        - c8a.medium
+        - m7a.medium
       ebs_size: 10
       ebs_optimized: True
       spot_instance: True

--- a/portal_objects/metaworkflows/ultra-long_reads_BAM_quality_metrics_GRCh38.yaml
+++ b/portal_objects/metaworkflows/ultra-long_reads_BAM_quality_metrics_GRCh38.yaml
@@ -723,6 +723,6 @@ workflows:
         - m7a.medium
       ebs_size: 10
       ebs_optimized: True
-      spot_instance: True
+      spot_instance: False
       run_name: run_parse-qc_BAM_Quality_Metrics_single-end_verifybamid2
       behavior_on_capacity_limit: wait_and_retry


### PR DESCRIPTION
* Replace the `t3.small` instance with `c7a.medium`, `c8a.medium`, and `m7a.medium` because `t3.small` is no longer reliable